### PR TITLE
Add html file for google domain verification

### DIFF
--- a/layouts/google6201d784d1d80e36.html
+++ b/layouts/google6201d784d1d80e36.html
@@ -1,0 +1,1 @@
+google-site-verification: google6201d784d1d80e36.html


### PR DESCRIPTION
Google prefers to have a specific HTML file at the root of the site that allows it to verify our domain ownership.