### PR TITLE
Google domain site verification file

### DIFF
--- a/static/google6201d784d1d80e36.html
+++ b/static/google6201d784d1d80e36.html
@@ -1,0 +1,1 @@
+google-site-verification: google6201d784d1d80e36.html


### PR DESCRIPTION
Google wants to have a specific file at the root of the domain so they can verify ownership of the site.